### PR TITLE
Just noticed a missing paren with the img tag

### DIFF
--- a/js/core/config.sample.js
+++ b/js/core/config.sample.js
@@ -68,7 +68,7 @@ var config = {
       quote: '<q>{content}</q>',
       code: '<code>{content}</code>',
       url: '<a href="{option}">{content}</a>',
-      img: '<img src="{content}" alt="Image({content}" />',
+      img: '<img src="{content}" alt="Image({content})" />',
       color: '<span style="color:{option}">{content}</span>'
     },
 


### PR DESCRIPTION
Just noticed this while my mind was dwelling on dark matters such as grepping the xhtml output. I dont know if that's a good idea but at least im useful now.
